### PR TITLE
Fix README and Replace Reference to Team Chicken in index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 
-# Iteration 2 Team Chicken <!-- omit in toc -->
+# Iteration 3 Team Vibing Cats <!-- omit in toc -->
 
 [![Server Build Status](../../actions/workflows/server.yml/badge.svg)](../../actions/workflows/server.yml)
 [![Client Build Status](../../actions/workflows/client.yaml/badge.svg)](../../actions/workflows/client.yaml)
 [![End to End Build Status](../../actions/workflows/e2e.yaml/badge.svg)](../../actions/workflows/e2e.yaml)
 
-[![BCH compliance](https://bettercodehub.com/edge/badge/UMM-CSci-3601-S21/it-2-it-2-chicken?branch=main)](https://bettercodehub.com/)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/UMM-CSci-3601-S21/it-2-it-2-chicken.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/UMM-CSci-3601-S21/it-2-it-2-chicken/alerts/)
+[![BCH compliance](https://bettercodehub.com/edge/badge/UMM-CSci-3601-S21/it-3-vibing-cats?branch=main)](https://bettercodehub.com/)
+[![Total alerts](https://img.shields.io/lgtm/alerts/g/UMM-CSci-3601-S21/it-3-vibing-cats.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/UMM-CSci-3601-S21/it-3-vibing-cats/alerts/)
 - [Development](#development)
   - [Common commands](#common-commands)
 - [Deployment](#deployment)

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Team Chicken</title>
+    <title>Vibing Cats</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />


### PR DESCRIPTION
This commit modifies the links in the README file in order to point things toward our team's repository for this iteration and not the previous one. Additionally, in index.html, a reference to Team Chicken was replaced with Vibing Cats. This was updated to reflect the name of our team.

Co-authored-by: Richard Lussier <lussi036@morris.umn.edu>
Co-authored-by:  Joshua Eklund <eklun124@umn.edu>
Co-authored-by:  Jacob Jenness <jenne077@morris.umn.edu>
Co-authored-by:  Elena Lam <lam00071@morris.umn.edu>
Co-authored-by:  Biruk Mengistu <mengi024@morris.umn.edu>