### PR TITLE
Fix issue with deleting a context pack

### DIFF
--- a/client/cypress/integration/wordlist.spec.ts
+++ b/client/cypress/integration/wordlist.spec.ts
@@ -56,8 +56,9 @@ describe('WordList', () => {
         page.clickDeleteContextPack().click();
         page.getDeleteContextPackConfirmation().should('be.visible');
         page.getDeleteContextPackConfirmDeleteButton().click();
+        cy.wait(1000);
         cy.url().should('match', /\/home$/);
-        page.getCpCards().should('have.length', 3);
+        page.getCpCards().should('have.length', 2);
 
     });
 

--- a/client/cypress/support/login.po.ts
+++ b/client/cypress/support/login.po.ts
@@ -14,7 +14,7 @@ export class LoginPage {
     }
 
     login(){
-        this.loginEmail().type('cats@gmail.com');
+        this.loginEmail().type('cats3@gmail.com');
         this.loginPassword().type('VibingCats');
         this.loginButton().click();
     }

--- a/client/src/app/wordlists/display-wordlist/display-wordlist.component.spec.ts
+++ b/client/src/app/wordlists/display-wordlist/display-wordlist.component.spec.ts
@@ -9,6 +9,8 @@ import { DisplayWordlistComponent } from './display-wordlist.component';
 import { MockCPService } from 'src/testing/context-pack.service.mock';
 import { ContextPackService } from 'src/app/services/contextPack-service/contextpack.service';
 import { of } from 'rxjs';
+import { LoginService } from 'src/app/services/login-service/login.service';
+import { LoginServiceMock } from 'src/testing/login-service-mock';
 
 describe('DisplayWordlistComponent', () => {
   let component: DisplayWordlistComponent;
@@ -31,6 +33,12 @@ describe('DisplayWordlistComponent', () => {
         useValue: {
           paramMap: of(paramMap)
         }
+      },
+      {
+        provide: LoginService, useValue: new LoginServiceMock({
+          email: 'biruk@gmail.com',
+          password: 'BirukMengistu', uid: '123'
+        })
       }
       ]
     })

--- a/client/src/app/wordlists/display-wordlist/display-wordlist.component.ts
+++ b/client/src/app/wordlists/display-wordlist/display-wordlist.component.ts
@@ -4,6 +4,7 @@ import { Component, OnInit } from '@angular/core';
 import { WordList } from 'src/app/datatypes/wordlist';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ContextPack } from 'src/app/datatypes/contextPacks';
+import { LoginService } from 'src/app/services/login-service/login.service';
 
 @Component({
   selector: 'app-display-wordlist',
@@ -23,7 +24,8 @@ export class DisplayWordlistComponent implements OnInit {
     private route: ActivatedRoute,
     private service: WordListService,
     private cpservice: ContextPackService,
-    private router: Router
+    private router: Router,
+    private login: LoginService
   ) { }
 
   ngOnInit(): void {
@@ -51,7 +53,7 @@ export class DisplayWordlistComponent implements OnInit {
   }
 
   delete(){
-    this.cpservice.deletePack(this.pack._id).subscribe((r)=>{
+    this.cpservice.deleteContextPackFromAll(this.login.user.authId, this.pack._id ).subscribe((r)=>{
       this.router.navigate(['home']);
     });
   }


### PR DESCRIPTION
This pull request fixes an issue with deleting a context pack where deleting it from the inside of a pack would not remove it from the user packs. This pull request also modifies the tests for this feature so that they pass with the new implementation.
Closes #49 
